### PR TITLE
Fix lint errors

### DIFF
--- a/pyslac/session.py
+++ b/pyslac/session.py
@@ -922,7 +922,8 @@ class SlacSessionController:
             await slac_session.evse_slac_parm()
             if slac_session.state == STATE_MATCHING:
                 logger.info(
-                    f"Matching ongoing (EVSE ID: {slac_session.evse_id}. Run ID: {slac_session.run_id})."
+                    f"Matching ongoing (EVSE ID: {slac_session.evse_id}. Run ID: "
+                    f"{slac_session.run_id})."
                 )
                 await self.notify_matching_ongoing(slac_session.evse_id)
                 try:
@@ -936,7 +937,8 @@ class SlacSessionController:
                     )
             if slac_session.state == STATE_MATCHED:
                 logger.info(
-                    f"PEV-EVSE MATCHED Successfully, Link Established (EVSE ID: {slac_session.evse_id}. Run ID: {slac_session.run_id})."
+                    "PEV-EVSE MATCHED Successfully, Link Established (EVSE ID: "
+                    f"{slac_session.evse_id}. Run ID: {slac_session.run_id})."
                 )
                 while True:
                     await asyncio.sleep(2.0)


### PR DESCRIPTION
`flake8` reported the following issues:

```
0.540 pyslac/session.py:925:89: E501 line too long (105 > 88 characters)
0.540 pyslac/session.py:939:89: E501 line too long (136 > 88 characters)
```

Fixes #44 