### PR TITLE
Change default network interfaces

### DIFF
--- a/pyslac/examples/cs_configuration.json
+++ b/pyslac/examples/cs_configuration.json
@@ -2,10 +2,10 @@
   "number_of_evses": 2,
   "parameters": [
 	{"evse_id": "DE*SWT*E123456789",
-	  "network_interface": "eth0"
+	  "network_interface": "lo"
 	},
 	{"evse_id": "DE*SWT*E5131456589",
-	  "network_interface": "eth1"
+	  "network_interface": "lo"
 	}
   ]
 }


### PR DESCRIPTION
By default, the `SlacSessionController` uses the interfaces `eth0` and `eth1`.

Since not every system has these interfaces, `make dev` and `make run-local-single` can fail. Using the loopback interface solves this this issue.

Fixes: #50 